### PR TITLE
macos: use macdeployot to bundle qt frameworks

### DIFF
--- a/build_macos
+++ b/build_macos
@@ -11,6 +11,8 @@ make clean
 make -j8
 rm -rf build/macos/obj
 cd build/macos
+# bundle up any dyanmically linked qt frameworks into the app.
+macdeployqt esc_tool_*.app
 zip -r esc_tool_vari_macos.zip `ls | grep -v '\.zip$'`
 ls | grep -v '\.zip$' | xargs rm -rf
 cd ../..


### PR DESCRIPTION
qt provided by homebrew on macos is by default dynamically linked.

if qt is dynamically linked (frameworks on macos) then the app bundle
needs to have qt libs copied in.  use macdeployqt tool from qt to do
this.

if QT is built statically linked,  this command should not be needed
but should also have no effect. (untested)