### PR TITLE
macos build, zip symlinks

### DIFF
--- a/build_macos
+++ b/build_macos
@@ -13,6 +13,6 @@ rm -rf build/macos/obj
 cd build/macos
 # bundle up any dyanmically linked qt frameworks into the app.
 macdeployqt esc_tool_*.app
-zip -r esc_tool_vari_macos.zip `ls | grep -v '\.zip$'`
+zip -r --symlinks esc_tool_vari_macos.zip `ls | grep -v '\.zip$'`
 ls | grep -v '\.zip$' | xargs rm -rf
 cd ../..


### PR DESCRIPTION
without `--symlinks` option to `zip`  symlinks are copied in as files.
with the bundled qt frameworks this would double the size of things